### PR TITLE
feat: Make ct zone id configurable for NAT lookups.

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-/usr/sbin/bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/common/vmlinux.h
+btf_file="/sys/kernel/btf/vmlinux"
+if [ -e "/sys/kernel/btf/nf_conntrack" ]; then
+    btf_file="/sys/kernel/btf/nf_conntrack"
+fi
+
+/usr/sbin/bpftool btf dump file "${btf_file}" format c >"bpf/common/vmlinux.h"
 ./bpf/libbpf/update.sh
 go mod tidy
 go generate ./...

--- a/bpf/common/math.h
+++ b/bpf/common/math.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))

--- a/bpf/common/nf_conntrack_bpf.h
+++ b/bpf/common/nf_conntrack_bpf.h
@@ -2,14 +2,17 @@
 
 #include "bpf.h"
 
-#define BPF_F_CURRENT_NETNS (-1)
+volatile const u16 CT_ZONE_ID = 0;
+volatile const u32 BPF_CT_OPTS_SIZE = NF_BPF_CT_OPTS_SZ;
 
-struct bpf_ct_opts {
+struct bpf_ct_opts___local {
   s32 netns_id;
   s32 error;
   u8 l4proto;
   u8 dir;
-  u8 reserved[2];
+  u16 ct_zone_id;
+  u8 ct_zone_dir;
+  u8 reserved[3];
 };
 
 extern struct nf_conn *bpf_xdp_ct_lookup(struct xdp_md *xdp_ctx,

--- a/bpf/libbpf/update.sh
+++ b/bpf/libbpf/update.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Version of libbpf to fetch headers from
-LIBBPF_VERSION=1.3.0
+LIBBPF_VERSION=1.4.2
 
 # The headers we want
 prefix="libbpf-${LIBBPF_VERSION}"
@@ -18,5 +18,5 @@ headers=(
 libbpf_dir=$(dirname "$0")
 
 # Fetch libbpf release and extract the desired headers
-curl -sL "https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz" | \
+curl -sL "https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz" |
     tar -C "${libbpf_dir}" -xz --xform='s#.*/##' "${headers[@]}"


### PR DESCRIPTION
This feature requires this kernel patch which will be part of linux v6.10:

https://lore.kernel.org/bpf/20240522050712.732558-1-brad@faucet.nz/t/#u

On older linux versions, tc-cpumap will always use the default ct zone (id=0).